### PR TITLE
Provide compatibility with Twig 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.2",
         "doctrine/inflector": "~1.0",
-        "twig/twig": "~1.12"
+        "twig/twig": "~1.12|~2.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
Twig 2 is out.  The classes are all compatible with Twig 1.x, so it should be safe to add compatibility in the `composer.json`.